### PR TITLE
Back-end - Updated naming of app setting

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -131,7 +131,7 @@ func GetAppSettings(key string) map[string]string {
 		"APP_FETCH_CREATE_PRICE_TIER_ENABLED",
 		"APP_FETCH_SYNC_IMAGES"}
 	shopify_keys := []string{"SHOPIFY_DEFAULT_PRICE_TIER", "SHOPIFY_DEFAULT_COMPARE_AT_PRICE_TIER",
-		"SHOPIFY_DISABLE_DYNAMIC_SKU_SEARCH"}
+		"SHOPIFY_ENABLE_DYNAMIC_SKU_SEARCH"}
 	if key == "app" {
 		for iterator, value := range app_keys {
 			result[app_keys[iterator]] = LoadEnv(value)

--- a/shopify_push.go
+++ b/shopify_push.go
@@ -188,22 +188,22 @@ func (dbconfig *DbConfig) PushProduct(configShopify *shopify.ConfigShopify, prod
 		_, err := configShopify.UpdateProductShopify(shopifyProduct, product_id)
 		return err
 	}
-	is_dynamic_search_disabled := true
-	dynamic_search_disabled, err := dbconfig.DB.GetAppSettingByKey(
+	dynamic_search_enabled := false
+	dynamic_search, err := dbconfig.DB.GetAppSettingByKey(
 		context.Background(),
-		"shopify_disable_dynamic_sku_search",
+		"shopify_enable_dynamic_sku_search",
 	)
 	if err != nil {
 		if err.Error() != "sql: no rows in result set" {
 			return err
 		}
-		dynamic_search_disabled.Value = "true"
+		dynamic_search.Value = "false"
 	}
-	is_dynamic_search_disabled, err = strconv.ParseBool(dynamic_search_disabled.Value)
+	dynamic_search_enabled, err = strconv.ParseBool(dynamic_search.Value)
 	if err != nil {
 		return err
 	}
-	if is_dynamic_search_disabled {
+	if !dynamic_search_enabled {
 		ids, err := configShopify.GetProductBySKU(product.Variants[0].Sku)
 		if err != nil {
 			return err

--- a/sql/schema/029_shopify_settings.sql
+++ b/sql/schema/029_shopify_settings.sql
@@ -28,9 +28,9 @@ INSERT INTO shopify_settings(
     NOW()
 ), (
     uuid_generate_v4(),
-    'shopify_disable_dynamic_sku_search',
+    'shopify_enable_dynamic_sku_search',
     'Enables the dynamic searching of SKUs on Shopify when adding new products. If disabled, only first product SKU will be considered.',
-    'Shopify Disable Dynamic SKU Search',
+    'Shopify Enable Dynamic SKU Search',
     'true',
     NOW(),
     NOW()


### PR DESCRIPTION
[Issue](https://github.com/Keenan-Faure/Shopify-Integrator/issues/290

Changed the format of the `shopify_disabled_dynamic_sku_search` shopify setting to be `enabled` as it is much more user friendly.

As a result the code had to be inverted as well.