### PR TITLE
split ci github actions into individual jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,33 +5,6 @@ on:
         branches: [main]
 
 jobs:
-    integration-tests:
-        name: integration tests
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Set up Go
-              uses: actions/setup-go@v4
-              with:
-                  go-version: "1.22"
-
-            - name: Check out code
-              uses: actions/checkout@v4
-
-            - name: Run install script
-              run: |
-                  chmod +x ./scripts/install.github.sh
-                  ./scripts/install.github.sh
-              shell: bash
-
-            - name: 🔎 Run unit tests
-              run: go test ./... -cover
-
-            - name: 🔎 Run Gosec Security Scanner
-              uses: securego/gosec@master
-              with:
-                args: -exclude-generated ./...
-
     build:
         name: build docker image
         runs-on: ubuntu-latest

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    style:
+        name: style
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version: "1.22"
+
+            - name: Check out code
+              uses: actions/checkout@v3
+
+            - name: 🔎 Run Gosec Security Scanner
+              uses: securego/gosec@master
+              with:
+                args: -exclude-generated ./...
+
+            - name: 🔎Check code formatting
+              run: test -z $(go fmt ./...)
+
+            - name: Install static check
+              run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+            - name: 🔎Static check
+              run: staticcheck ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: ci
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    integration-tests:
+        name: integration tests
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version: "1.22"
+
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Run install script
+              run: |
+                  chmod +x ./scripts/install.github.sh
+                  ./scripts/install.github.sh
+              shell: bash
+
+            - name: 🔎 Run unit tests
+              run: go test ./... -cover


### PR DESCRIPTION
[Issue](https://github.com/Keenan-Faure/Shopify-Integrator/issues/66)

Split `ci.yml` github action into:

- ci.yml (docker build)
- style.yml (formating, styling and static checks)
- tests.yml (integration-tests and unit tests)