### PR TITLE
Fix for broken Shopify Fetch

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -7,6 +7,15 @@ APP_HOST="http://localhost:3000"
 # either 'release' or 'debug'
 GIN_MODE=release
 
+# Google OAuth
+OAUTH_GOOGLE_CLIENT_ID=
+OAUTH_GOOGLE_SECRET=
+
+# Hosts
+APP_HOST=http://app.si
+DOCS_HOST=http://docs.si
+API_SERVER_HOST=http://api.si
+
 # Database
 DB_USER="postgres"
 DB_PSW="postgres"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ _note that this assumes that you have a shopify store with a valid ngrok authTok
 
 The application (v2) supports OAuth2.0 with google which allows users, if they have a google account, to login using their existing account with google.
 
-To use this feature `OAUTH_CLIENT_ID` AND `OAUTH_SECRET` needs to be configured in the `.env` file of the project. To obtain these access tokens, please follow the guide outlined [here](https://developers.google.com/identity/protocols/oauth2)
+To use this feature `OAUTH_GOOGLE_CLIENT_ID` AND `OAUTH_GOOGLE_SECRET` needs to be configured in the `.env` file of the project. To obtain these access tokens, please follow the guide outlined [here](https://developers.google.com/identity/protocols/oauth2)
 
 ## ⚙️ Usage
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ _note that this assumes that you have a shopify store with a valid ngrok authTok
 
 The application (v2) supports OAuth2.0 with google which allows users, if they have a google account, to login using their existing account with google.
 
-To use this feature `OAUTH_CLIENT_ID` AND `OAUTH_SECRET` needs to be configured. To obtain these access tokens, please follow the guide outlined [here](https://developers.google.com/identity/protocols/oauth2)
+To use this feature `OAUTH_CLIENT_ID` AND `OAUTH_SECRET` needs to be configured in the `.env` file of the project. To obtain these access tokens, please follow the guide outlined [here](https://developers.google.com/identity/protocols/oauth2)
 
 ## ⚙️ Usage
 

--- a/internal/shopify/shopify.go
+++ b/internal/shopify/shopify.go
@@ -16,7 +16,7 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
-const PRODUCT_FETCH_LIMIT = "20" // limit on products to fetch
+const PRODUCT_FETCH_LIMIT = "10" // limit on products to fetch
 
 type ConfigShopify struct {
 	APIKey      string
@@ -252,11 +252,8 @@ func (configShopify *ConfigShopify) GetShopifyLocations() (objects.ShopifyLocati
 func (configShopify *ConfigShopify) GetShopifyInventoryLevel(
 	location_id,
 	inventory_item_id string) (objects.GetShopifyInventoryLevels, error) {
-	if location_id == "" {
-		return objects.GetShopifyInventoryLevels{}, errors.New("invalid location id not allowed")
-	}
-	if inventory_item_id == "" {
-		return objects.GetShopifyInventoryLevels{}, errors.New("invalid inventory item id not allowed")
+	if location_id == "" && inventory_item_id == "" {
+		return objects.GetShopifyInventoryLevels{}, errors.New("invalid item not allowed")
 	}
 	res, err := configShopify.FetchHelper(
 		"inventory_levels.json?location_ids="+location_id+"&inventory_item_ids="+inventory_item_id,
@@ -287,11 +284,8 @@ func (configShopify *ConfigShopify) GetShopifyInventoryLevel(
 func (configShopify *ConfigShopify) GetShopifyInventoryLevels(
 	location_id,
 	inventory_item_id string) (objects.GetShopifyInventoryLevelsList, error) {
-	if location_id == "" {
-		return objects.GetShopifyInventoryLevelsList{}, errors.New("invalid location id not allowed")
-	}
-	if inventory_item_id == "" {
-		return objects.GetShopifyInventoryLevelsList{}, errors.New("invalid inventory item id not allowed")
+	if location_id == "" && inventory_item_id == "" {
+		return objects.GetShopifyInventoryLevelsList{}, errors.New("invalid item not allowed")
 	}
 	res, err := configShopify.FetchHelper(
 		"inventory_levels.json?location_ids="+location_id+"&inventory_item_ids="+inventory_item_id,
@@ -326,11 +320,8 @@ func (configShopify *ConfigShopify) AddLocationQtyShopify(
 		InventoryItemID:     inventory_item_id,
 		AvailableAdjustment: qty,
 	}
-	if location_id == 0 {
-		return objects.ResponseAddInventoryItem{}, errors.New("invalid location id not allowed")
-	}
-	if inventory_item_id == 0 {
-		return objects.ResponseAddInventoryItem{}, errors.New("invalid inventory item id not allowed")
+	if location_id == 0 && inventory_item_id == 0 {
+		return objects.ResponseAddInventoryItem{}, errors.New("invalid item not allowed")
 	}
 	var buffer bytes.Buffer
 	err := json.NewEncoder(&buffer).Encode(inventory_adjustment)

--- a/internal/shopify/shopify.go
+++ b/internal/shopify/shopify.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -71,7 +72,7 @@ func (configShopify *ConfigShopify) UpdateShopifyWebhook(
 		return objects.ShopifyWebhookRequest{}, err
 	}
 	res, err := configShopify.FetchHelper(
-		"webhooks.json",
+		"webhooks/"+fmt.Sprint(int_webhook_id)+".json",
 		http.MethodPut,
 		&buffer,
 	)
@@ -754,6 +755,7 @@ func (shopifyConfig *ConfigShopify) FetchHelper(endpoint, method string, body io
 	httpClient := http.Client{
 		Timeout: time.Second * 20,
 	}
+	fmt.Println(shopifyConfig.Url + "/" + endpoint)
 	req, err := http.NewRequest(method, shopifyConfig.Url+"/"+endpoint, body)
 	if err != nil {
 		return &http.Response{}, err

--- a/internal/shopify/test_payloads/test-case-valid-level-item-adjust.json
+++ b/internal/shopify/test_payloads/test-case-valid-level-item-adjust.json
@@ -1,0 +1,9 @@
+{
+    "inventory_level": {
+        "inventory_item_id": 23087120381,
+        "location_id": 10293810823,
+        "available": 5,
+        "updated_at": "2024-04-01T13:24:55-04:00",
+        "admin_graphql_api_id": "gid://shopify/InventoryLevel/655441491?inventory_item_id=49148385"
+    }
+}

--- a/main.go
+++ b/main.go
@@ -86,6 +86,11 @@ func setUpAPI(dbconfig *DbConfig) *gin.Engine {
 	nauth.POST("/register", dbconfig.RegisterHandle())
 	nauth.POST("/login", dbconfig.LoginHandle())
 
+	/* OAuth2.0 */
+	nauth.GET("/google/login", dbconfig.OAuthGoogleLogin())
+	nauth.GET("/google/callback", dbconfig.OAuthGoogleCallback())
+	nauth.GET("/google/oauth2/login", dbconfig.OAuthGoogleOAuth())
+
 	/* --------- Auth routes --------- */
 	auth := r.Group("/api")
 
@@ -172,11 +177,6 @@ func setUpAPI(dbconfig *DbConfig) *gin.Engine {
 	auth.POST("/queue", dbconfig.QueuePush())
 	auth.DELETE("/queue", dbconfig.ClearQueueByFilter())
 	auth.DELETE("/queue/:id", dbconfig.ClearQueueByID())
-
-	/* OAuth2.0 */
-	auth.GET("/google/login", dbconfig.OAuthGoogleLogin())
-	auth.GET("/google/callback", dbconfig.OAuthGoogleCallback())
-	auth.GET("/google/oauth2/login", dbconfig.OAuthGoogleOAuth())
 
 	/* setup file server */
 	r.StaticFS("/static", gin.Dir("./app/export", true))

--- a/oauth2.go
+++ b/oauth2.go
@@ -39,9 +39,9 @@ const oauthGoogleUrlAPI = "https://www.googleapis.com/oauth2/v2/userinfo?access_
 var hashKey = []byte("nSTDTVzvNdflcOlclhuaSFJfrkzKdBJjKTeRAhTVVFyiHqrUcNgvmhfXAvlGYpmv")
 
 var googleOauthConfig = &oauth2.Config{
-	RedirectURL:  "http://localhost:8080/api/google/callback",
-	ClientID:     utils.LoadEnv("OAUTH_CLIENT_ID"),
-	ClientSecret: utils.LoadEnv("OAUTH_SECRET"),
+	RedirectURL:  utils.LoadEnv("API_SERVER_HOST") + "/api/google/callback",
+	ClientID:     utils.LoadEnv("OAUTH_GOOGLE_CLIENT_ID"),
+	ClientSecret: utils.LoadEnv("OAUTH_GOOGLE_SECRET"),
 	// scopes on which to retrieve the userinfo from google api
 	Scopes: []string{
 		"https://www.googleapis.com/auth/userinfo.email",
@@ -101,7 +101,7 @@ func (dbconfig *DbConfig) OAuthGoogleCallback() gin.HandlerFunc {
 			if encoded, err := s.Encode(cookie_name, value); err == nil {
 				c.SetCookie(cookie_name, encoded, 0, "/", "", false, false)
 			}
-			c.Redirect(http.StatusSeeOther, "http://localhost:3000/")
+			c.Redirect(http.StatusSeeOther, utils.LoadEnv("APP_HOST"))
 			return
 		}
 		// user validation
@@ -150,7 +150,7 @@ func (dbconfig *DbConfig) OAuthGoogleCallback() gin.HandlerFunc {
 		}
 		// redirect back to the application login screen where the user logins in automatically
 		// using the new credentials
-		c.Redirect(http.StatusSeeOther, "http://localhost:3000/")
+		c.Redirect(http.StatusSeeOther, utils.LoadEnv("APP_HOST"))
 	}
 }
 


### PR DESCRIPTION
- Reduced the amount of products to fetch from Shopify to `10`
- Added future host names to the `.example.env` for future purposes
- Updated OAuth to contain dynamic values
- Updated and fixed some tests that were failing
